### PR TITLE
ci: add golangci-lint GitHub Action and update Go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.4'
+        cache: false
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+        args: --timeout=30m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/markgx/gofeedfinder
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for golangci-lint code quality checks
- Update Go version from 1.24.2 to 1.24.4 in both go.mod and workflow configuration

## Test plan
- [ ] Verify workflow triggers on push to main and pull requests
- [ ] Confirm golangci-lint runs successfully with Go 1.24.4
- [ ] Check that code quality checks pass for existing codebase