### PR TITLE
feat: add version flag and Makefile with git-based versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ go.work.sum
 
 # env file
 .env
+
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Get version from git tags, fallback to commit hash
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+
+# Build flags for version injection
+LDFLAGS = -ldflags "-X main.version=$(VERSION)"
+
+# Binary output directory
+BIN_DIR = bin
+
+.PHONY: build install dev test clean help
+
+# Default target
+all: build
+
+# Build the binary
+build:
+	@mkdir -p $(BIN_DIR)
+	go build $(LDFLAGS) -o $(BIN_DIR)/gofeedfinder ./cmd/gofeedfinder
+
+# Install to GOPATH/bin
+install:
+	go install $(LDFLAGS) ./cmd/gofeedfinder
+
+# Run directly without building binary
+dev:
+	go run $(LDFLAGS) ./cmd/gofeedfinder
+
+# Run tests
+test:
+	go test -v ./...
+
+# Run tests with coverage
+test-cover:
+	go test -v -cover ./...
+
+# Run static analysis
+vet:
+	go vet ./...
+
+# Clean build artifacts
+clean:
+	rm -rf $(BIN_DIR)
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  build      - Build the binary to $(BIN_DIR)/gofeedfinder"
+	@echo "  install    - Install binary to GOPATH/bin"
+	@echo "  dev        - Run directly with 'go run'"
+	@echo "  test       - Run all tests"
+	@echo "  test-cover - Run tests with coverage"
+	@echo "  vet        - Run static analysis"
+	@echo "  clean      - Remove build artifacts"
+	@echo "  help       - Show this help"
+	@echo ""
+	@echo "Version: $(VERSION)"

--- a/cmd/gofeedfinder/main.go
+++ b/cmd/gofeedfinder/main.go
@@ -8,12 +8,20 @@ import (
 	"github.com/markgx/gofeedfinder/pkg/gofeedfinder"
 )
 
+var version = "dev"
+
 func main() {
 	withAttributes := flag.Bool("with-attributes", false, "Display additional feed attributes")
+	showVersion := flag.Bool("version", false, "Show version information")
 	flag.Parse()
 
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
 	if len(flag.Args()) < 1 {
-		fmt.Println("Usage: gofeedfinder [--with-attributes] <url>")
+		fmt.Println("Usage: gofeedfinder [--with-attributes] [--version] <url>")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
- Add `--version` flag to CLI that outputs version information
- Create Makefile with git describe-based version injection using ldflags
- Version automatically reflects git tags and commit state (e.g., `v1.0.0`, `v1.0.0-5-g1a2b3c4-dirty`)